### PR TITLE
fix: 修改“岗位管理”-查询、排序、重置、全部导出到excel等的错误

### DIFF
--- a/src/views/system/post/index.vue
+++ b/src/views/system/post/index.vue
@@ -110,7 +110,7 @@ function openDialog(type: "add" | "update", row?: PostPageResponse) {
           type="primary"
           :icon="useRenderIcon(Search)"
           :loading="pageLoading"
-          @click="onSearch"
+          @click="onSearch(tableRef)"
         >
           搜索
         </el-button>

--- a/src/views/system/post/utils/hook.tsx
+++ b/src/views/system/post/utils/hook.tsx
@@ -16,8 +16,8 @@ const statusMap = useUserStoreHook().dictionaryMap["common.status"];
 
 export function usePostHook() {
   const defaultSort: Sort = {
-    prop: "createTime",
-    order: "descending"
+    prop: "post_sort",
+    order: "ascending"
   };
 
   const pagination: PaginationProps = {
@@ -80,6 +80,7 @@ export function usePostHook() {
     {
       label: "岗位排序",
       prop: "postSort",
+      sortable: "custom",
       minWidth: 120
     },
     {
@@ -114,13 +115,18 @@ export function usePostHook() {
 
   function onSortChanged(sort: Sort) {
     sortState.value = sort;
-    onSearch();
+    // 表格列的排序变化的时候，需要重置分页
+    pagination.currentPage = 1;
+    getPostList(sort);
   }
 
-  async function onSearch() {
-    // 点击搜索的时候 需要重置分页
+  async function onSearch(tableRef) {
+    // 点击搜索的时候，需要重置分页
     pagination.currentPage = 1;
-    getPostList();
+    // 点击搜索的时候，需要清空表格上列的排序
+    tableRef.getTableRef().clearSort();
+    // 使用默认排序发起请求
+    getPostList(defaultSort);
   }
 
   function resetForm(formEl, tableRef) {
@@ -134,9 +140,8 @@ export function usePostHook() {
     // Form组件的resetFields方法无法清除datepicker里面的数据。
     searchFormParams.beginTime = undefined;
     searchFormParams.endTime = undefined;
-    tableRef.getTableRef().clearSort();
     // 重置分页并查询
-    onSearch();
+    onSearch(tableRef);
   }
 
   async function getPostList(sort: Sort = defaultSort) {

--- a/src/views/system/post/utils/hook.tsx
+++ b/src/views/system/post/utils/hook.tsx
@@ -121,21 +121,14 @@ export function usePostHook() {
   }
 
   async function onSearch(tableRef) {
-    // 点击搜索的时候，需要重置分页
-    pagination.currentPage = 1;
-    // 点击搜索的时候，需要清空表格上列的排序
-    tableRef.getTableRef().clearSort();
-    // 使用默认排序发起请求
-    getPostList();
+    // 点击搜索的时候，需要重置排序，重新排序的时候会重置分页并发起查询请求
+    tableRef.getTableRef().sort("postSort", "ascending");
   }
 
   function resetForm(formEl, tableRef) {
     if (!formEl) return;
     // 清空查询参数
     formEl.resetFields();
-    // 清空排序
-    searchFormParams.orderColumn = undefined;
-    searchFormParams.orderDirection = undefined;
     // 清空时间查询  TODO  这块有点繁琐  有可以优化的地方吗？
     // Form组件的resetFields方法无法清除datepicker里面的数据。
     searchFormParams.beginTime = undefined;

--- a/src/views/system/post/utils/hook.tsx
+++ b/src/views/system/post/utils/hook.tsx
@@ -166,8 +166,8 @@ export function usePostHook() {
   }
 
   async function handleDelete(row) {
-    await deletePostApi([row.logId]).then(() => {
-      message(`您删除了操作编号为${row.logId}的这条数据`, {
+    await deletePostApi([row.postId]).then(() => {
+      message(`您删除了编号为${row.postId}的这条岗位数据`, {
         type: "success"
       });
       // 刷新列表
@@ -182,7 +182,7 @@ export function usePostHook() {
     }
 
     ElMessageBox.confirm(
-      `确认要<strong>删除</strong>编号为<strong style='color:var(--el-color-primary)'>[ ${multipleSelection.value} ]</strong>的日志吗?`,
+      `确认要<strong>删除</strong>编号为<strong style='color:var(--el-color-primary)'>[ ${multipleSelection.value} ]</strong>的岗位数据吗?`,
       "系统提示",
       {
         confirmButtonText: "确定",
@@ -194,7 +194,7 @@ export function usePostHook() {
     )
       .then(async () => {
         await deletePostApi(multipleSelection.value).then(() => {
-          message(`您删除了日志编号为[ ${multipleSelection.value} ]的数据`, {
+          message(`您删除了编号为[ ${multipleSelection.value} ]的岗位数据`, {
             type: "success"
           });
           // 刷新列表

--- a/src/views/system/post/utils/hook.tsx
+++ b/src/views/system/post/utils/hook.tsx
@@ -16,7 +16,7 @@ const statusMap = useUserStoreHook().dictionaryMap["common.status"];
 
 export function usePostHook() {
   const defaultSort: Sort = {
-    prop: "post_sort",
+    prop: "postSort",
     order: "ascending"
   };
 
@@ -117,7 +117,7 @@ export function usePostHook() {
     sortState.value = sort;
     // 表格列的排序变化的时候，需要重置分页
     pagination.currentPage = 1;
-    getPostList(sort);
+    getPostList();
   }
 
   async function onSearch(tableRef) {
@@ -126,7 +126,7 @@ export function usePostHook() {
     // 点击搜索的时候，需要清空表格上列的排序
     tableRef.getTableRef().clearSort();
     // 使用默认排序发起请求
-    getPostList(defaultSort);
+    getPostList();
   }
 
   function resetForm(formEl, tableRef) {
@@ -144,11 +144,9 @@ export function usePostHook() {
     onSearch(tableRef);
   }
 
-  async function getPostList(sort: Sort = defaultSort) {
+  async function getPostList() {
     pageLoading.value = true;
-    if (sort != null) {
-      CommonUtils.fillSortParams(searchFormParams, sort);
-    }
+    CommonUtils.fillSortParams(searchFormParams, sortState.value);
     CommonUtils.fillPaginationParams(searchFormParams, pagination);
 
     const { data } = await getPostListApi(toRaw(searchFormParams)).finally(

--- a/src/views/system/post/utils/hook.tsx
+++ b/src/views/system/post/utils/hook.tsx
@@ -162,7 +162,7 @@ export function usePostHook() {
     CommonUtils.fillPaginationParams(searchFormParams, pagination);
     CommonUtils.fillTimeRangeParams(searchFormParams, timeRange.value);
 
-    exportPostExcelApi(toRaw(searchFormParams), "岗位数据.xls");
+    exportPostExcelApi(toRaw(searchFormParams), "岗位数据.xlsx");
   }
 
   async function handleDelete(row) {


### PR DESCRIPTION
岗位管理是一个最基本的CRUD，针对查询、排序、导出等功能的全面排查修改来提取标准的页面模板（计划供后续的代码生成器用）。后端代码也一并做了修改提交了PR，当前已经合并到后端仓库中了。