### PR TITLE
Fix: Ensure route.children existence before accessing in initRouter() and Fix serverConfig.json fetching behavior across nested routes

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,7 +31,7 @@ export const getServerConfig = async (app: App): Promise<undefined> => {
   app.config.globalProperties.$config = getConfig();
   return axios({
     method: "get",
-    url: `${VITE_PUBLIC_PATH}serverConfig.json`
+    url: `${window.location.origin}/serverConfig.json`
   })
     .then(({ data: config }) => {
       let $config = app.config.globalProperties.$config;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -158,7 +158,12 @@ router.beforeEach((to: ToRouteType, _from, next) => {
             getTopMenu(true);
             // query、params模式路由传参数的标签页不在此处处理
             if (route && route.meta?.title) {
-              if (isAllEmpty(route.parentId) && route.meta?.backstage) {
+              if (
+                isAllEmpty(route.parentId) &&
+                route.meta?.backstage &&
+                route.children &&
+                route.children.length > 0
+              ) {
                 // 此处为动态顶级路由（目录）
                 const { path, name, meta } = route.children[0];
                 useMultiTagsStoreHook().handleTags("push", {


### PR DESCRIPTION
In the initRouter() function, added a check to ensure the existence of route.children before accessing it. This prevents the "TypeError: Cannot read properties of undefined" error that occurred when trying to access route.children[0] without confirming its existence. The check ensures that route.children is present and not an empty array before proceeding to access its elements.