### PR TITLE
fix: 修复启动时的异常TypeError: (0 , import_theme.default) is not a function

### DIFF
--- a/build/plugins.ts
+++ b/build/plugins.ts
@@ -8,7 +8,7 @@ import { configCompressPlugin } from "./compress";
 // import ElementPlus from "unplugin-element-plus/vite";
 import { visualizer } from "rollup-plugin-visualizer";
 import removeConsole from "vite-plugin-remove-console";
-import themePreprocessorPlugin from "@pureadmin/theme";
+import { themePreprocessorPlugin } from "@pureadmin/theme";
 import { genScssMultipleScopeVars } from "../src/layout/theme";
 
 export function getPluginsList(


### PR DESCRIPTION
修复启动错误
vite.config.tserror when starting dev server:
TypeError: (0 , import_theme.default) is not a function